### PR TITLE
Centralize logging setup

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Dict, Any, Optional
 import logging
 
-# 設置日誌
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def setup_logging() -> None:
+    """Configure basic logging for the application."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+

--- a/main_app.py
+++ b/main_app.py
@@ -5,11 +5,6 @@ from PyQt5.QtGui import QIcon
 from config.config_manager import config_manager
 from ui.main_window import ModernMainWindow
 
-# 設置日誌
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
 logger = logging.getLogger(__name__)
 
 def main():

--- a/run.py
+++ b/run.py
@@ -8,6 +8,9 @@ import sys
 import os
 from pathlib import Path
 
+from logging_setup import setup_logging
+setup_logging()
+
 # 確保專案根目錄在 Python 路徑中
 project_root = Path(__file__).parent
 if str(project_root) not in sys.path:


### PR DESCRIPTION
## Summary
- centralize logging configuration via new `logging_setup` and call it from `run.py`
- remove direct `logging.basicConfig` calls from modules in favor of `logging.getLogger(__name__)`

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5250b431c83218efb6bb394972082