### PR TITLE
Use shutil.which for executable checks

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -3,12 +3,12 @@
 支援開發和 PyInstaller 打包環境
 """
 
-import os
-import sys
 import json
-from pathlib import Path
-from typing import Dict, Any, Optional
 import logging
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 # 設置日誌
 logging.basicConfig(level=logging.INFO)
@@ -124,14 +124,9 @@ class ConfigManager:
     def _check_executable(self, path: str) -> bool:
         """檢查執行檔是否存在且可執行"""
         try:
-            if os.path.isfile(path) and os.access(path, os.X_OK):
-                return True
-            # 檢查是否在 PATH 中
-            if any(os.path.isfile(os.path.join(p, path)) for p in os.environ.get("PATH", "").split(os.pathsep)):
-                return True
+            return shutil.which(path) is not None
         except Exception:
-            pass
-        return False
+            return False
     
     def get(self, key: str, default: Any = None) -> Any:
         """

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+from config.config_manager import ConfigManager
+
+
+def test_check_executable_with_absolute_path():
+    cm = ConfigManager()
+    assert cm._check_executable(sys.executable)
+
+
+def test_check_executable_with_basename_in_path():
+    cm = ConfigManager()
+    exe_name = Path(sys.executable).name
+    assert cm._check_executable(exe_name)
+
+
+def test_check_executable_with_stem_in_path():
+    cm = ConfigManager()
+    exe_stem = Path(sys.executable).stem
+    assert cm._check_executable(exe_stem)
+
+
+def test_check_executable_not_found():
+    cm = ConfigManager()
+    assert not cm._check_executable("not_a_real_command")


### PR DESCRIPTION
## Summary
- Simplify executable detection by using `shutil.which`
- Remove manual PATH scanning logic
- Add tests for common executable lookup scenarios

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_config_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5250ec0d08321aea03fe0492496c7