### PR TITLE
feat: expose cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 │   └── poppler/plugin.py
 ├── build.py                 # 自動化打包
 ├── cli_tool.spec           # PyInstaller 配置
-├── run.py                  # 統一啟動入口
+├── run.py                  # 開發者啟動腳本
 └── test_*.py               # 測試腳本
 ```
 
@@ -252,7 +252,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### 從 v1.x 升級到 v2.0
 1. **配置遷移**: 舊的硬編碼設定需遷移到 `config/cli_tool_config.json`
-2. **啟動方式**: 建議使用 `python run.py` 作為統一入口
+2. **啟動方式**: 建議使用 `cli-tool` 指令作為統一入口
 3. **依賴安裝**: 執行 `pip install -r requirements.txt`
 4. **功能驗證**: 運行 `python test_simple.py` 驗證升級結果
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ pip install -r requirements-dev.txt
 python test_simple.py
 
 # 5. 運行應用程式
-python run.py
+cli-tool
 ```
 
 ## 🏗️ 專案架構
@@ -41,7 +41,7 @@ cli_tool/
 ├── static/                 # 靜態資源
 ├── tests/                  # 測試文件
 ├── main_app.py             # 主應用程式
-├── run.py                  # 啟動腳本
+├── run.py                  # 開發者啟動腳本
 ├── build.py                # 打包腳本
 ├── cli_tool.spec           # PyInstaller 配置
 └── setup.py                # 安裝配置
@@ -203,7 +203,7 @@ pytest tests/
 
 ### 開發模式運行
 ```bash
-python run.py
+cli-tool
 ```
 
 ### 打包為執行檔

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ pip install -r requirements-dev.txt
 
 ### 2. 運行應用程式
 ```bash
-# 方法 1: 使用啟動腳本
-python run.py
+# 安裝後使用 CLI 指令
+cli-tool
 
-# 方法 2: 直接運行主程式
+# 開發模式（直接運行主程式）
 python main_app.py
 ```
 
@@ -214,7 +214,7 @@ pyinstaller --onefile --windowed main_app.py
 ```
 cli_tool/
 ├── main_app.py              # 主應用程式
-├── run.py                   # 啟動腳本
+├── run.py                   # 開發者啟動腳本
 ├── build.py                 # 自動化打包腳本
 ├── cli_tool.spec            # PyInstaller 配置文件
 ├── setup.py                 # 套件安裝配置

--- a/run.py
+++ b/run.py
@@ -1,20 +1,12 @@
 #!/usr/bin/env python3
-"""
-CLI Tool 應用程式啟動腳本
-提供統一的啟動入口點
+"""CLI Tool 應用程式啟動腳本。
+
+這個腳本不再修改 ``sys.path`` 或 ``PYTHONPATH``，
+取而代之的是依賴於 package 安裝時設定的入口點。
 """
 
 import sys
-import os
-from pathlib import Path
 
-# 確保專案根目錄在 Python 路徑中
-project_root = Path(__file__).parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
-
-# 設置環境變數
-os.environ['PYTHONPATH'] = str(project_root)
 
 def main():
     """主函數"""


### PR DESCRIPTION
## Summary
- streamline run script by dropping manual `sys.path`/`PYTHONPATH` hacks and rely on package entry point
- document `cli-tool` command as primary way to launch the app
- update developer and changelog docs to reflect new entry point and run script role

## Testing
- `pytest tests/cli_tool/test_pdf_decryptor.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `apt-get update` *(fails: 403 Forbidden when fetching Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68a5251dd4bc8321ace5d372894afaf5